### PR TITLE
Блокировка микрофона на время воспроизведения ответа

### DIFF
--- a/run_remoteva_vosk.py
+++ b/run_remoteva_vosk.py
@@ -155,7 +155,9 @@ if __name__ == "__main__":
 
                                         if "saywav" in ttsFormatList:
                                             play_wav.saywav_to_file(res,'tmpfile.wav')
+                                            mic_blocked = True
                                             play_wav.play_wav('tmpfile.wav')
+                                            mic_blocked = False
 
                         except requests.ConnectionError as e:
                             play_wav.play_wav('error_connection.wav')


### PR DESCRIPTION
Пожалуйста, протестируйте, что это работает с [новым play_wav.py](https://github.com/janvarev/Remote-Irene/commit/0711f018176ab54d0e39a96b787a5f4f91c782c6), использующим модуль audioplayer.
У меня по какой-то причине ответ в виде wav не слышен, причём нет логов об ошибке. Поэтому пока для себя вернул прошлую версию файла.